### PR TITLE
feat: add webhook_secret handling and validations for FlutterwaveProv…

### DIFF
--- a/app/models/payment_providers/flutterwave_provider.rb
+++ b/app/models/payment_providers/flutterwave_provider.rb
@@ -10,12 +10,10 @@ module PaymentProviders
     PROCESSING_STATUSES = %w[pending].freeze
     SUCCESS_STATUSES = %w[successful].freeze
     FAILED_STATUSES = %w[failed cancelled].freeze
-
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}
 
-    secrets_accessors :secret_key
-    settings_accessors :webhook_secret
+    secrets_accessors :secret_key, :webhook_secret
 
     before_create :generate_webhook_secret
 

--- a/spec/factories/payment_providers.rb
+++ b/spec/factories/payment_providers.rb
@@ -106,13 +106,12 @@ FactoryBot.define do
     type { "PaymentProviders::FlutterwaveProvider" }
     name { "Flutterwave" }
     code { "flutterwave_#{SecureRandom.uuid}" }
-
     secrets do
-      {secret_key:}.to_json
+      {secret_key:, webhook_secret:}.to_json
     end
 
     settings do
-      {success_redirect_url:, webhook_secret:}
+      {success_redirect_url:}
     end
 
     transient do

--- a/spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe PaymentProviders::Flutterwave::HandleEventJob do
       after { ENV.delete("SIDEKIQ_PAYMENTS") }
 
       it "uses the payments queue" do
-        expect(described_class.queue_name).to eq("payments")
+        expect {
+          described_class.perform_later(organization:, event: "test")
+        }.to have_enqueued_job.on_queue("payments")
       end
     end
 
@@ -35,7 +37,9 @@ RSpec.describe PaymentProviders::Flutterwave::HandleEventJob do
       before { ENV.delete("SIDEKIQ_PAYMENTS") }
 
       it "uses the providers queue" do
-        expect(described_class.queue_name).to eq("providers")
+        expect {
+          described_class.perform_later(organization:, event: "test")
+        }.to have_enqueued_job.on_queue("providers")
       end
     end
   end

--- a/spec/models/payment_providers/flutterwave_provider_spec.rb
+++ b/spec/models/payment_providers/flutterwave_provider_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::FlutterwaveProvider, type: :model do
+  subject(:flutterwave_provider) { build(:flutterwave_provider) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:secret_key) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to allow_value(nil).for(:success_redirect_url) }
+    it { is_expected.to allow_value("https://example.com/success").for(:success_redirect_url) }
+    it { is_expected.not_to allow_value("invalid-url").for(:success_redirect_url) }
+    it { is_expected.not_to allow_value("a" * 1025).for(:success_redirect_url) }
+
+    it "validates uniqueness of the code" do
+      expect(flutterwave_provider).to validate_uniqueness_of(:code).scoped_to(:organization_id)
+    end
+  end
+
+  describe "constants" do
+    it "defines success redirect URL" do
+      expect(described_class::SUCCESS_REDIRECT_URL).to eq("https://www.flutterwave.com/ng")
+    end
+
+    it "defines API URL" do
+      expect(described_class::API_URL).to eq("https://api.flutterwave.com/v3")
+    end
+
+    it "defines processing statuses" do
+      expect(described_class::PROCESSING_STATUSES).to eq(%w[pending])
+    end
+
+    it "defines success statuses" do
+      expect(described_class::SUCCESS_STATUSES).to eq(%w[successful])
+    end
+
+    it "defines failed statuses" do
+      expect(described_class::FAILED_STATUSES).to eq(%w[failed cancelled])
+    end
+  end
+
+  describe "#payment_type" do
+    it "returns flutterwave" do
+      expect(flutterwave_provider.payment_type).to eq("flutterwave")
+    end
+  end
+
+  describe "#api_url" do
+    it "returns the API URL" do
+      expect(flutterwave_provider.api_url).to eq("https://api.flutterwave.com/v3")
+    end
+  end
+
+  describe "webhook_secret generation" do
+    context "when creating a new provider" do
+      it "generates a webhook secret" do
+        provider = create(:flutterwave_provider)
+        expect(provider.webhook_secret).to be_present
+        expect(provider.webhook_secret.length).to eq(64)
+      end
+
+      it "generates different secrets for different providers" do
+        provider1 = create(:flutterwave_provider)
+        provider2 = create(:flutterwave_provider)
+        expect(provider1.webhook_secret).not_to eq(provider2.webhook_secret)
+      end
+
+      it "does not override existing webhook secret" do
+        existing_secret = "existing_secret"
+        provider = described_class.new(
+          organization: create(:organization),
+          name: "Test Provider",
+          code: "test_provider",
+          secret_key: "test_key",
+          webhook_secret: existing_secret
+        )
+        provider.save!
+        expect(provider.reload.webhook_secret).to eq(existing_secret)
+      end
+    end
+  end
+
+  describe "FlutterwavePayment" do
+    it "defines a data structure for payments" do
+      payment = described_class::FlutterwavePayment.new(
+        id: "12345",
+        status: "successful",
+        metadata: {amount: 1000}
+      )
+
+      expect(payment.id).to eq("12345")
+      expect(payment.status).to eq("successful")
+      expect(payment.metadata).to eq({amount: 1000})
+    end
+  end
+
+  describe "secrets accessors" do
+    it "provides access to secret_key through secrets" do
+      provider = create(:flutterwave_provider, secret_key: "test_secret_key")
+      expect(provider.secret_key).to eq("test_secret_key")
+    end
+
+    it "provides access to webhook_secret through secrets" do
+      provider = create(:flutterwave_provider)
+      expect(provider.webhook_secret).to be_present
+    end
+  end
+end

--- a/spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe PaymentProviders::Flutterwave::HandleIncomingWebhookService do
       let(:secret) { nil }
 
       before do
-        flutterwave_provider.update!(settings: flutterwave_provider.settings.merge("webhook_secret" => nil))
+        secrets = JSON.parse(flutterwave_provider.secrets || "{}")
+        secrets.delete("webhook_secret")
+        flutterwave_provider.update!(secrets: secrets.to_json)
       end
 
       it "returns service failure" do


### PR DESCRIPTION
### **User description**
This pull request introduces several changes to enhance the functionality and testing of the `FlutterwaveProvider` payment provider. Key updates include improving secrets management, refining test cases, and adding comprehensive model validations.

### Enhancements to secrets management:
* [`app/models/payment_providers/flutterwave_provider.rb`](diffhunk://#diff-a414a7d079b42ff13c72f34ed850a2d8e8f8545948cd12a734b84b495bf42c65L13-R16): Added `webhook_secret` to `secrets_accessors` to centralize its management alongside `secret_key`.
* [`spec/factories/payment_providers.rb`](diffhunk://#diff-b00a08bd058b9bfb7207663dfab54ea320064b98593acd3743e991bd07a5fc5eL109-R114): Updated the `secrets` and `settings` attributes in the factory to reflect the new secrets structure, ensuring `webhook_secret` is properly handled.
* [`spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb`](diffhunk://#diff-2a7cc93a53c9aea68690e38ee6cf037d539c0d5e23ec8bcde9a63727ba975d46L66-R68): Adjusted the test setup to remove `webhook_secret` from the `secrets` JSON structure instead of `settings`.

### Improvements to test coverage:
* [`spec/models/payment_providers/flutterwave_provider_spec.rb`](diffhunk://#diff-a77a14ee03d8a08081cd3c54025f577b31f9d80a0d5e73420378a49c77a48d96R1-R109): Added extensive tests for validations, constants, secrets accessors, webhook secret generation, and the `FlutterwavePayment` data structure to ensure robust functionality.

### Refinements in job queue testing:
* [`spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb`](diffhunk://#diff-12aa7935b144d19d57fa1f212576558fcd31a7876e16aacd69f89f6ecde6fe19L30-R42): Updated tests to use `have_enqueued_job` matcher, improving readability and accuracy in verifying job queue assignments.


___

### **PR Type**
Enhancement


___

### **Description**
• Moved `webhook_secret` from settings to secrets for better security
• Added comprehensive test coverage for FlutterwaveProvider model
• Fixed queue testing to use proper enqueue matchers
• Updated factory to reflect new secrets structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flutterwave_provider.rb</strong><dd><code>Move webhook_secret to secrets accessors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/models/payment_providers/flutterwave_provider.rb

• Moved <code>webhook_secret</code> from <code>settings_accessors</code> to <code>secrets_accessors</code><br> • <br>Removed extra blank line for cleaner formatting


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/lago-api/pull/3/files#diff-a414a7d079b42ff13c72f34ed850a2d8e8f8545948cd12a734b84b495bf42c65">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>payment_providers.rb</strong><dd><code>Update factory for new secrets structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/factories/payment_providers.rb

• Added <code>webhook_secret</code> to secrets JSON structure<br> • Removed <br><code>webhook_secret</code> from settings hash<br> • Added transient <code>webhook_secret</code> <br>attribute


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/lago-api/pull/3/files#diff-b00a08bd058b9bfb7207663dfab54ea320064b98593acd3743e991bd07a5fc5e">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>handle_event_job_spec.rb</strong><dd><code>Fix queue testing with proper matchers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/jobs/payment_providers/flutterwave/handle_event_job_spec.rb

• Replaced <code>queue_name</code> assertions with <code>have_enqueued_job.on_queue</code> <br>matchers<br> • Added proper job enqueuing expectations for both queue <br>scenarios


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/lago-api/pull/3/files#diff-12aa7935b144d19d57fa1f212576558fcd31a7876e16aacd69f89f6ecde6fe19">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flutterwave_provider_spec.rb</strong><dd><code>Add comprehensive FlutterwaveProvider model tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/models/payment_providers/flutterwave_provider_spec.rb

• Added comprehensive test suite for FlutterwaveProvider model<br> • Tests <br>validations, constants, webhook secret generation, and data structures<br> <br>• Covers secrets accessors and payment type functionality


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/lago-api/pull/3/files#diff-a77a14ee03d8a08081cd3c54025f577b31f9d80a0d5e73420378a49c77a48d96">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>handle_incoming_webhook_service_spec.rb</strong><dd><code>Update webhook service test for secrets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/services/payment_providers/flutterwave/handle_incoming_webhook_service_spec.rb

• Updated test to remove <code>webhook_secret</code> from secrets JSON instead of <br>settings<br> • Fixed webhook secret handling test for new secrets <br>structure


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/lago-api/pull/3/files#diff-2a7cc93a53c9aea68690e38ee6cf037d539c0d5e23ec8bcde9a63727ba975d46">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>